### PR TITLE
Vorher: Build über scripts/build.ps1 + build/version.json, Loader mit dynamischem GitHub-Runtime-Download.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+﻿node_modules/
+*.log
+npm-debug.log*
+.tmp-domain-tests/
+.tmp-runtime-contract/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+﻿# AGENTS.md
 
 Repository guide for humans and coding agents.
 
@@ -7,24 +7,52 @@ Repository guide for humans and coding agents.
 - Keep tournament logic deterministic, testable, and aligned with DRA/PDC terminology.
 
 ## Source of truth
-- Logic: `src/*`
-- Built artifact: `dist/autodarts-tournament-assistant.user.js`
-- Do not edit `dist/*` manually. Use `scripts/build.ps1`.
+- Logic and runtime behavior: `src/*`
+- Build/distribution tooling: `scripts/*`, `package.json`
+- Built artifacts: `dist/*`
+- Legacy fallback loader: `installer/Autodarts Tournament Assistant Loader.user.js`
+- Do not edit `dist/*` manually. Always build via `npm run build` or `powershell -ExecutionPolicy Bypass -File scripts/build.ps1`.
+
+## Mandatory change boundaries
+- Packaging/build/versioning/distribution changes are allowed and expected.
+- Tournament Fachlogik, API-Halbautomatik flow, UI behavior and runtime order must stay unchanged unless technically required.
+- No silent changes to:
+  - storage keys
+  - DOM selectors/hooks
+  - event names
+  - initialization order or side effects
+  - runtime guards (`__ATA_RUNTIME_BOOTSTRAPPED`, `__ATA_RUNTIME`, loader/runtime bridge keys)
+- Keep legacy loader in repo until explicitly removed by maintainers.
 
 ## Required workflow for changes
-1. Understand affected layer(s): `core`, `data`, `domain`, `app`, `infra`, `ui`, `runtime`.
-2. Implement in `src/*` only.
-3. Add or update tests in `tests/*`.
-4. Run at minimum:
+1. Identify affected layer(s): `core`, `data`, `domain`, `app`, `infra`, `ui`, `runtime`.
+2. Implement in small, reviewable steps.
+3. Prefer adapter/wrapper changes over deep refactors for migration tasks.
+4. Add/update tests in `tests/*` and/or `scripts/*` when behavior or build mechanics change.
+5. Run at minimum:
+   - `npm run build`
+   - `npm run check:syntax`
+   - `npm test`
    - `powershell -ExecutionPolicy Bypass -File scripts/test-domain.ps1`
    - `powershell -ExecutionPolicy Bypass -File scripts/test-runtime-contract.ps1`
-5. Before finalize, run:
+6. Before finalize, run:
    - `powershell -ExecutionPolicy Bypass -File scripts/qa.ps1`
 
 ## Architecture rules
 - Domain layer must stay pure (no `window`, `document`, storage, rendering).
 - UI should not own domain decisions; call app/domain functions.
 - Infra is best-effort integration and must fail safely.
+- Runtime bootstrap remains idempotent and single-init.
+
+## Userscript packaging rules
+- Version source is `package.json`.
+- Build must produce:
+  - `dist/autodarts-local-tournament.user.js`
+  - `dist/autodarts-local-tournament.meta.js`
+  - legacy aliases under `dist/autodarts-tournament-assistant.*`
+- Metadata header must include complete userscript fields and correct `@downloadURL` / `@updateURL`.
+- Keep only technically required grants/connect entries.
+- New standard install path must work without dynamic GitHub runtime download.
 
 ## Rule compliance expectations
 - Reference documents:
@@ -39,14 +67,17 @@ Repository guide for humans and coding agents.
 - Return explicit `reasonCode` for blocked/failed flows.
 - Keep backward compatibility for persisted storage where possible.
 - Keep docs in sync with code behavior.
+- For risky migrations, document risks and rollback path in PR/release notes.
 
 ## Test strategy minimum
 - Unit tests for pure domain logic.
 - Scenario tests for full mode flows (`ko`, `league`, `groups_ko`).
 - Runtime selftests for integration-sensitive behavior.
+- Build verification for dist/meta/header/version consistency.
 
 ## Documentation hygiene
 - Update when behavior changes:
   - `README.md`
   - `docs/changelog.md`
   - Compliance docs if rule behavior changes.
+- For packaging/distribution changes, include upgrade and rollback notes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lokales Turniermanagement direkt in `https://play.autodarts.io` als Userscript.
 
-[![Installieren](https://img.shields.io/badge/Installieren-Autodarts%20Tournament%20Assistant%20Loader-1f6feb?style=for-the-badge)](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js)
+[![Installieren](https://img.shields.io/badge/Installieren-Autodarts%20Local%20Tournament-1f6feb?style=for-the-badge)](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js)
 
 Der Assistent erweitert die Autodarts-Oberfläche um einen eigenen Bereich für:
 - Turnieranlage (KO, Liga, Gruppenphase + KO)
@@ -51,16 +51,18 @@ Zusätzliche Detaildoku zur Zeitberechnung: [docs/tournament-duration.md](docs/t
 4. `https://play.autodarts.io` neu laden.
 5. Links im Menü **xLokales Turnier** öffnen.
 
-Empfohlen ist die Installation über den Loader:
+Empfohlen ist die direkte Dist-Installation (ohne Remote-Runtime-Loader):
 
-[![ATA Loader installieren](https://img.shields.io/badge/ATA%20Loader-installieren-1f6feb?style=for-the-badge)](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js)
+[![ATA Dist installieren](https://img.shields.io/badge/ATA%20Dist-installieren-1f6feb?style=for-the-badge)](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js)
 
-Alternative ohne Loader:
-- Direktes Runtime-Skript: [autodarts-tournament-assistant.user.js](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js)
+Legacy-Fallback (deprecated):
+- Loader: [Autodarts Tournament Assistant Loader.user.js](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js)
+- Legacy-Alias der Runtime: [autodarts-tournament-assistant.user.js](https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js)
 
 Wichtiger Hinweis nach der Installation:
-- Bei Loader-Installation reicht für Updates ein Reload von `play.autodarts.io`.
-- Bei direkter Runtime-Installation erscheint im Tab `Einstellungen` eine GitHub-Update-Prüfung mit `Update installieren`.
+- Der neue Standardpfad ist `dist/autodarts-local-tournament.user.js` (kein dynamischer Runtime-Download von GitHub).
+- Bei direkter Dist-Installation erscheint im Tab `Einstellungen` eine GitHub-Update-Prüfung mit `Update installieren`.
+- Der Loader bleibt nur als Legacy-/Fallback-Pfad im Repo und zeigt einen Migrationshinweis auf den neuen Installer.
 - Falls Tampermonkey nicht in `play.autodarts.io` injiziert, siehe [Tampermonkey FAQ](https://www.tampermonkey.net/faq.php#Q209).
 
 ![Sidebar-Eintrag xLokales Turnier](assets/ss_autodarts-menu-xLokales-Turnier.png)
@@ -424,11 +426,11 @@ Legende für die eingeblendeten Hilfelinks:
 
 ### Script-Update
 - Der Tab `Einstellungen` prüft die veröffentlichte GitHub-Version gegen die installierte Runtime-Version.
-- Die Prüfung nutzt `dist/autodarts-tournament-assistant.meta.js` als primären Versions-Endpoint und fällt bei Bedarf auf `dist/autodarts-tournament-assistant.user.js` zurück.
+- Die Prüfung nutzt `dist/autodarts-local-tournament.meta.js` als primären Versions-Endpoint und fällt bei Bedarf auf `dist/autodarts-local-tournament.user.js` zurück.
 - Direkt installierte Runtime:
   - Button `Update installieren` öffnet die veröffentlichte Userscript-Datei mit Cache-Busting.
 - Loader aktiv:
-  - Bei verfügbarer neuer Runtime genügt `Neu laden`, weil der Loader die aktuelle Dist-Datei beim nächsten Seitenaufruf frisch lädt.
+  - Loader ist nur noch Legacy-Fallback; der empfohlene Wechsel ist auf die direkte Dist-Installation.
 - Der Sidebar-Menüeintrag `xLokales Turnier` markiert verfügbare Updates zusätzlich mit einem Punkt.
 
 ### Automatischer Lobby-Start + API-Sync
@@ -569,10 +571,12 @@ autodarts_local_tournament/
 |  |- runtime/
 |- build/
 |  |- manifest.json
-|  |- version.json
 |  `- domain-test-manifest.json
 |- scripts/
 |  |- build.ps1
+|  |- build-userscript.mjs
+|  |- check-syntax.mjs
+|  |- run-tests.mjs
 |  |- qa.ps1
 |  |- qa-architecture.ps1
 |  |- qa-build-discipline.ps1
@@ -592,8 +596,10 @@ autodarts_local_tournament/
 |- installer/
 |  |- Autodarts Tournament Assistant Loader.user.js
 |- dist/
-|  |- autodarts-tournament-assistant.meta.js
+|  |- autodarts-local-tournament.meta.js
+|  |- autodarts-local-tournament.user.js
 |  |- autodarts-tournament-assistant.user.js
+|  `- autodarts-tournament-assistant.meta.js
 |- docs/
 |  |- architecture.md
 |  |- codebase-map.md
@@ -606,21 +612,27 @@ autodarts_local_tournament/
 |- assets/
 |- README.md
 |- LICENSE
+|- package.json
 ```
 
 Die vollständige Datei- und Verbindungsdoku steht in [docs/codebase-map.md](docs/codebase-map.md).
 
 ### Hauptdateien
 - Quellcode: `src/*`
-- Build-Metadaten: `build/manifest.json`, `build/version.json`
-- Build/QA: `scripts/*.ps1`
-- Runtime-Script: `dist/autodarts-tournament-assistant.user.js`
-- Meta-Endpoint für Versionsabgleich: `dist/autodarts-tournament-assistant.meta.js`
-- Loader-Script: `installer/Autodarts Tournament Assistant Loader.user.js`
+- Build-Metadaten: `build/manifest.json`
+- Versionsquelle: `package.json`
+- Build/QA: `scripts/*.mjs`, `scripts/*.ps1`
+- Empfohlenes Runtime-Script: `dist/autodarts-local-tournament.user.js`
+- Empfohlener Meta-Endpoint: `dist/autodarts-local-tournament.meta.js`
+- Legacy-Loader: `installer/Autodarts Tournament Assistant Loader.user.js`
+- Legacy-Runtime-Alias: `dist/autodarts-tournament-assistant.user.js`
 
 ### Build und QA
 ```powershell
-powershell -ExecutionPolicy Bypass -File scripts/build.ps1
+npm install
+npm run build
+npm run check:syntax
+npm test
 powershell -ExecutionPolicy Bypass -File scripts/qa.ps1
 ```
 
@@ -631,6 +643,25 @@ powershell -ExecutionPolicy Bypass -File scripts/qa-architecture.ps1
 powershell -ExecutionPolicy Bypass -File scripts/test-domain.ps1
 powershell -ExecutionPolicy Bypass -File scripts/test-runtime-contract.ps1
 ```
+
+Smoke-Test (manuell):
+1. Frisches Browserprofil + Tampermonkey starten.
+2. `dist/autodarts-local-tournament.user.js` installieren.
+3. `https://play.autodarts.io/*` öffnen.
+4. Prüfen, dass `xLokales Turnier` genau einmal injiziert wird.
+5. Tabs `Turnier`, `Spiele`, `Turnierbaum`, `Import/Export`, `Einstellungen` öffnen.
+6. In der Konsole auf doppelte Handler-/Bootstrap-Anzeichen prüfen.
+7. Optional Legacy-Loader separat installieren und den Deprecation-Hinweis mit Migrationsbutton prüfen.
+
+Upgrade-Test (manuell):
+1. Bestehende Installation in Tampermonkey öffnen.
+2. Neue Version von `dist/autodarts-local-tournament.user.js` installieren.
+3. Sicherstellen, dass bestehende Turnierdaten erhalten bleiben und keine Doppelinitialisierung auftritt.
+
+Rollback-Test (manuell):
+1. Aktuelle Dist-Version in Tampermonkey deaktivieren.
+2. Entweder vorherige Dist-Version oder den Legacy-Loader installieren.
+3. Seite neu laden und Grundfunktionen (`xLokales Turnier`, Tabs, Matchliste) prüfen.
 
 ### Architektur
 - Shadow DOM für gekapselte UI

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,49 +1,84 @@
-# SKILL.md
+﻿# SKILL.md
 
 ## Name
-ATA Quality and Compliance Skill
+ATA Userscript Migration and Packaging Safety Skill
 
 ## Use when
-- Implementing or reviewing tournament logic.
-- Changing DRA/PDC-related behavior.
-- Touching import/sync/autodetect flows.
-- Preparing releases with high confidence.
+- Migrating install/distribution paths.
+- Changing userscript build/packaging/versioning metadata.
+- Touching `dist/*`, loader behavior, update URLs, or release verification.
 
-## Primary objectives
-- Preserve deterministic tournament behavior.
-- Keep DRA/PDC mapping explicit and auditable.
-- Prevent regressions via domain + runtime tests.
+## Do not change unless technically required
+- Tournament logic in `src/domain/*`
+- Runtime event order / side effects
+- Storage keys and migration semantics
+- DOM selectors/hooks for Autodarts integration
+- Global/runtime guard names
 
-## Operating procedure
-1. Map the change to affected layer(s).
-2. Identify impacted rule(s) and docs:
-   - `docs/DRA-RULE_BOOK.pdf`
-   - `docs/dra-regeln-gui.md`
-   - `docs/dra-compliance-matrix.md`
-3. Implement in `src/*` only.
-4. Add tests:
-   - Pure unit tests for functions.
-   - Scenario tests that run complete tournament paths.
-5. Rebuild and run checks:
-   - `powershell -ExecutionPolicy Bypass -File scripts/build.ps1`
-   - `powershell -ExecutionPolicy Bypass -File scripts/test-domain.ps1`
-   - `powershell -ExecutionPolicy Bypass -File scripts/test-runtime-contract.ps1`
-   - `powershell -ExecutionPolicy Bypass -File scripts/qa.ps1`
-6. Update docs/changelog if behavior changed.
+## Standard build and packaging flow
+1. Install dependencies:
+```powershell
+npm install
+```
+2. Build userscript artifacts:
+```powershell
+npm run build
+```
+3. Required artifacts in `dist/`:
+- `autodarts-local-tournament.user.js`
+- `autodarts-local-tournament.meta.js`
+- `autodarts-tournament-assistant.user.js` (legacy alias)
+- `autodarts-tournament-assistant.meta.js` (legacy alias)
+4. Ensure version in header and runtime matches `package.json`.
 
-## Quality checklist
-- No hidden side effects in domain logic.
-- Explicit failure modes (`reasonCode`, message).
-- No ambiguous auto-writes when mapping is unclear.
-- Migration/backward compatibility considered.
-- Docs match real behavior and wording is consistent.
+## Metadata/header checks
+- Header must include:
+  - `@name`, `@namespace`, `@version`, `@description`, `@author`, `@license`
+  - `@match`, `@run-at`
+  - all required `@grant`
+  - only required `@connect`
+  - valid `@downloadURL`, `@updateURL`
+- Canonical files must point URLs to `autodarts-local-tournament.*`.
+- Legacy alias files must point URLs to `autodarts-tournament-assistant.*`.
 
-## Scenario-test expectations
-- `ko`: seeded/byes, open_draw determinism, advancement, champion/result index.
-- `league`: standings, tie-break ordering, playoff-required deadlocks.
-- `groups_ko`: group resolution, cross-semis, final assignment, deadlock blocking.
+## Syntax and automated checks
+Run in this order:
+```powershell
+npm run check:syntax
+npm test
+powershell -ExecutionPolicy Bypass -File scripts/test-domain.ps1
+powershell -ExecutionPolicy Bypass -File scripts/test-runtime-contract.ps1
+powershell -ExecutionPolicy Bypass -File scripts/qa.ps1
+```
 
-## Done criteria
-- All QA scripts green.
-- New behavior covered by automated tests.
-- Compliance text and changelog updated where relevant.
+## Smoke test (manual)
+1. Fresh browser profile.
+2. Tampermonkey installed.
+3. Install `dist/autodarts-local-tournament.user.js`.
+4. Open `https://play.autodarts.io/*`.
+5. Verify single initialization and visible ATA UI.
+6. Verify no duplicate handlers/injections.
+7. Verify legacy loader can still be installed separately.
+8. Verify standard path does not require GitHub runtime download at runtime.
+
+## Upgrade test (manual)
+1. Existing installation present.
+2. Install newer dist version over it.
+3. Verify persisted data remains.
+4. Verify no double-install side effects.
+5. Verify update/download URLs are sensible.
+
+## Rollback test (manual)
+1. Disable/remove new dist version.
+2. Install previous dist version or legacy loader.
+3. Reload `play.autodarts.io`.
+4. Verify baseline UI and tournament actions still work.
+5. Document exact rollback steps and known caveats.
+
+## Regression warning signals
+- More than one ATA bootstrap per page load.
+- Missing `window.__ATA_RUNTIME` or missing runtime API keys.
+- Broken sidebar entry insertion or duplicate menu entries.
+- Any change to storage keys or reason codes without migration/docs.
+- Dist header/version mismatch between `.user.js`, `.meta.js`, and `package.json`.
+- Build/test commands dirtying tracked repo files unexpectedly.

--- a/dist/autodarts-local-tournament.meta.js
+++ b/dist/autodarts-local-tournament.meta.js
@@ -11,7 +11,7 @@
 // @grant        GM_setValue
 // @grant        GM_xmlhttpRequest
 // @connect      api.autodarts.io
-// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js
-// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.meta.js
+// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js
+// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.meta.js
 // ==/UserScript==
 

--- a/dist/autodarts-local-tournament.user.js
+++ b/dist/autodarts-local-tournament.user.js
@@ -11,8 +11,8 @@
 // @grant        GM_setValue
 // @grant        GM_xmlhttpRequest
 // @connect      api.autodarts.io
-// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js
-// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.meta.js
+// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js
+// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.meta.js
 // ==/UserScript==
 
 (() => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Diese Datei erklärt die Architektur auf hoher Ebene.
 Die vollständige Ordner- und Dateikarte inklusive Build-/Runtime-Verbindungen steht in [codebase-map.md](codebase-map.md).
 
 ## Überblick
-Der Assistent ist in fachliche Schichten aufgeteilt und wird weiterhin als einzelnes Userscript ausgeliefert (`dist/autodarts-tournament-assistant.user.js`).
+Der Assistent ist in fachliche Schichten aufgeteilt und wird weiterhin als einzelnes Userscript ausgeliefert (`dist/autodarts-local-tournament.user.js`).
 
 - `src/core`: Konstanten, State, Utilities, Events, Logging
 - `src/domain`: fachliche Turnierregeln, pure Match-/KO-/Standings-/Zeitprognose-Logik
@@ -26,11 +26,13 @@ Der Assistent ist in fachliche Schichten aufgeteilt und wird weiterhin als einze
 - `runtime -> core, app, infra, ui`
 
 ## Build und Distribution
-- Der Build läuft ohne npm/Node über `scripts/build.ps1`.
-- Die Reihenfolge ist deterministisch über `build/manifest.json`.
-- Die Versionsquelle liegt in `build/version.json` und wird beim Build in Header und `APP_VERSION` injiziert.
+- Die Versionsquelle liegt in `package.json`.
+- Der Build läuft über `scripts/build-userscript.mjs` (esbuild), optional über den Wrapper `scripts/build.ps1`.
+- Die Modulreihenfolge bleibt deterministisch über `build/manifest.json`.
 - CSS liegt in `src/ui/styles/main.css` und wird beim Build in das Bundle eingebettet.
-- Der Build erzeugt `dist/autodarts-tournament-assistant.user.js` plus den leichten Versions-Endpoint `dist/autodarts-tournament-assistant.meta.js`.
+- Der Build erzeugt:
+  - `dist/autodarts-local-tournament.user.js` + `dist/autodarts-local-tournament.meta.js` (Standard)
+  - `dist/autodarts-tournament-assistant.user.js` + `dist/autodarts-tournament-assistant.meta.js` (Legacy-Alias)
 - `dist/*` bleibt ein generiertes Artefakt und wird nicht manuell gepflegt.
 
 ## Runtime

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,15 @@
 ﻿# Changelog
 
 ## Unreleased
+- Dist-First Packaging-Migration umgesetzt:
+  - `package.json` als zentrale Versionsquelle eingeführt.
+  - neuer reproduzierbarer Build via `scripts/build-userscript.mjs` (esbuild, `iife`, browser).
+  - neuer Standard-Installationspfad: `dist/autodarts-local-tournament.user.js` + `.meta.js`.
+  - Legacy-Alias-Dateien `dist/autodarts-tournament-assistant.*` bleiben für Update-Kompatibilität erhalten.
+  - neue Prüfskripte `scripts/check-syntax.mjs` und `scripts/run-tests.mjs` ergänzt.
+  - `scripts/build.ps1` auf den neuen Build-Flow umgestellt.
+  - Runtime- und Domain-Testharness schreiben in echte Temp-Verzeichnisse statt getrackter `.tmp/*`-Dateien.
+  - Legacy-Loader bleibt verfügbar, ist aber klar als deprecated markiert und zeigt einmalig einen Migrationshinweis auf den neuen Installer.
 - KO-Phasen fachlich sauber benannt:
   - KO-Ansicht und Matchkarten zeigen jetzt offizielle Endphasenbezeichnungen (`Achtelfinale`, `Viertelfinale`, `Halbfinale`, `Finale`).
   - Frühere große KO-Stufen bleiben als `Letzte 32`, `Letzte 64` usw. statt künstlicher `...finale`-Labels benannt.

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -102,6 +102,9 @@ autodarts_local_tournament/
 |  |- version.json
 |  `- domain-test-manifest.json
 |- scripts/
+|  |- build-userscript.mjs
+|  |- check-syntax.mjs
+|  |- run-tests.mjs
 |  |- build.ps1
 |  |- qa.ps1
 |  |- qa-architecture.ps1
@@ -127,6 +130,8 @@ autodarts_local_tournament/
 |- installer/
 |  `- Autodarts Tournament Assistant Loader.user.js
 |- dist/
+|  |- autodarts-local-tournament.meta.js
+|  |- autodarts-local-tournament.user.js
 |  |- autodarts-tournament-assistant.meta.js
 |  `- autodarts-tournament-assistant.user.js
 |- docs/
@@ -148,27 +153,28 @@ autodarts_local_tournament/
 ```
 
 ## Build- und Auslieferungspfad
-Der Build bleibt bewusst einfach: kein npm, kein Bundler-Framework, keine Zwischenpakete. Stattdessen werden die Quellmodule in der Reihenfolge aus `build/manifest.json` gelesen, zu einer Userscript-Datei zusammengeführt und mit eingebettetem CSS sowie eingebettetem PDC-Logo ausgegeben.
+Der Build bleibt bewusst einfach: npm-Skripte mit einem schlanken, reproduzierbaren esbuild-Flow ohne komplexes Framework. Die Quellmodule werden in der Reihenfolge aus `build/manifest.json` gelesen, zu einer Userscript-Datei zusammengeführt und mit eingebettetem CSS sowie eingebettetem PDC-Logo ausgegeben.
 
 Praktischer Ablauf:
 
 1. `build/manifest.json` definiert die Reihenfolge der Quelldateien.
-2. `build/version.json` ist die zentrale Versionsquelle für das Runtime-Bundle.
-3. `scripts/build.ps1` liest diese Dateien, lädt jedes Modul, entfernt alte Split-Marker und fügt die Inhalte zusammen.
-4. Dasselbe Skript injiziert die App-Version sowie `src/ui/styles/main.css` und `assets/pdc_logo.png` direkt ins Bundle.
-5. Das Ergebnis landet als installierbare Runtime-Datei in `dist/autodarts-tournament-assistant.user.js` plus leichtgewichtigem Versions-Header in `dist/autodarts-tournament-assistant.meta.js`.
-6. Der Loader in `installer/Autodarts Tournament Assistant Loader.user.js` lädt die veröffentlichte Runtime-Datei remote und nutzt bei Bedarf einen Cache-Fallback.
+2. `package.json` ist die zentrale Versionsquelle für das Runtime-Bundle.
+3. `scripts/build-userscript.mjs` liest diese Dateien, lädt jedes Modul, entfernt alte Split-Marker und fügt die Inhalte zusammen.
+4. Dasselbe Skript injiziert die App-Version sowie `src/ui/styles/main.css` und `assets/pdc_logo.png` direkt ins Bundle und transpiliert mit esbuild (`iife`, browser).
+5. Das Ergebnis landet als installierbare Runtime-Datei in `dist/autodarts-local-tournament.user.js` plus leichtgewichtigem Versions-Header in `dist/autodarts-local-tournament.meta.js`.
+6. Zusätzlich werden Legacy-Alias-Dateien `dist/autodarts-tournament-assistant.*` erzeugt, damit bestehende Installationen updatefähig bleiben.
+7. Der Loader in `installer/Autodarts Tournament Assistant Loader.user.js` bleibt als Legacy-Fallback erhalten (deprecated), lädt aber weiterhin remote und nutzt bei Bedarf einen Cache-Fallback.
 
 ```mermaid
 flowchart LR
   manifest["build/manifest.json"]
-  version["build/version.json"]
+  version["package.json"]
   src["src/**/*.js"]
   css["src/ui/styles/main.css"]
   logo["assets/pdc_logo.png"]
-  build["scripts/build.ps1"]
-  dist["dist/autodarts-tournament-assistant.user.js"]
-  meta["dist/autodarts-tournament-assistant.meta.js"]
+  build["scripts/build-userscript.mjs"]
+  dist["dist/autodarts-local-tournament.user.js"]
+  meta["dist/autodarts-local-tournament.meta.js"]
   loader["installer/Autodarts Tournament Assistant Loader.user.js"]
 
   manifest -->|bestimmt Modulreihenfolge| build
@@ -178,7 +184,7 @@ flowchart LR
   logo -->|wird als Data-URI eingebettet| build
   build -->|erzeugt Runtime| dist
   build -->|erzeugt Versions-Header| meta
-  loader -.->|lädt veröffentlichte dist-Datei remote<br/>und nutzt Cache-Fallback| dist
+  loader -.->|legacy fallback: lädt veröffentlichte dist-Datei remote<br/>und nutzt Cache-Fallback| dist
 ```
 
 Wichtig dabei:
@@ -320,20 +326,23 @@ Die Tabellen unten beschreiben pro Datei:
 
 | Datei | Rolle | Wichtige Inhalte / Hauptfunktionen | Primäre Verbindungen |
 |---|---|---|---|
-| `build/manifest.json` | Reihenfolgevertrag des Bundles | listet alle `src/*.js`-Module in deterministischer Reihenfolge | `scripts/build.ps1`, `src/core/constants.js`, `src/runtime/bootstrap.js` |
-| `build/version.json` | zentrale Versionsquelle | liefert `APP_VERSION` für Runtime-Header, Runtime-Code und Meta-Datei | `scripts/build.ps1`, `src/core/constants.js`, `dist/autodarts-tournament-assistant.user.js`, `dist/autodarts-tournament-assistant.meta.js` |
+| `build/manifest.json` | Reihenfolgevertrag des Bundles | listet alle `src/*.js`-Module in deterministischer Reihenfolge | `scripts/build-userscript.mjs`, `src/core/constants.js`, `src/runtime/bootstrap.js` |
+| `package.json` | zentrale Versionsquelle | liefert `version` für Runtime-Header, Runtime-Code und Meta-Datei | `scripts/build-userscript.mjs`, `scripts/qa-build-discipline.ps1`, `dist/*` |
 | `build/domain-test-manifest.json` | Test-Bundle-Vertrag | definiert, welche Dateien in den isolierten Domain-Harness geladen werden | `scripts/test-domain.ps1`, `tests/test-harness.js`, `tests/unit-*.js` |
-| `scripts/build.ps1` | Build-Orchestrierung | liest Manifest und Version, fügt Module zusammen, injiziert Version, bettet CSS und Logo ein, schreibt Runtime- und Meta-Artefakte nach `dist/*` | `build/manifest.json`, `build/version.json`, `src/ui/styles/main.css`, `assets/pdc_logo.png`, `dist/autodarts-tournament-assistant.user.js`, `dist/autodarts-tournament-assistant.meta.js` |
+| `scripts/build-userscript.mjs` | Build-Orchestrierung | liest Manifest und `package.json`, fügt Module zusammen, injiziert Version, bettet CSS und Logo ein, transpiliert via esbuild und schreibt Runtime-/Meta-Artefakte nach `dist/*` | `build/manifest.json`, `package.json`, `src/ui/styles/main.css`, `assets/pdc_logo.png`, `dist/autodarts-local-tournament.user.js`, `dist/autodarts-local-tournament.meta.js`, Legacy-Alias in `dist/autodarts-tournament-assistant.*` |
+| `scripts/build.ps1` | Kompatibilitäts-Wrapper | ruft den Node-Build (`scripts/build-userscript.mjs`) auf | `scripts/build-userscript.mjs` |
 | `scripts/qa.ps1` | Gesamt-QA | ruft Build, Architektur-QA, Encoding, Regelcheck, Domain-Harness, Runtime-Contract und Build-Disziplin auf | `scripts/build.ps1`, `scripts/qa-architecture.ps1`, `scripts/test-domain.ps1`, `scripts/test-runtime-contract.ps1`, `scripts/qa-build-discipline.ps1` |
 | `scripts/qa-architecture.ps1` | Architektur-Gate | prüft Domain-Reinheit, Runtime-/Bracket-/Storage-Grenzen und UI-Renderer-Regeln | `src/domain/*`, `src/bracket/*`, `src/data/storage.js`, `src/runtime/*`, `src/ui/render-*.js` |
-| `scripts/qa-encoding.ps1` | Zeichensatz- und Terminologie-Prüfung | prüft UTF-8, Mojibake und zentrale UI-Begriffe in Quell-, Dist- und Doku-Dateien | `src/*`, `dist/autodarts-tournament-assistant.user.js`, `docs/*`, `README.md` |
-| `scripts/qa-regelcheck.ps1` | fachlicher Regex-Check | prüft in `dist/*`, ob zentrale Regelmappings, KO-Logik und Terminologie im Bundle vorkommen | `dist/autodarts-tournament-assistant.user.js`, Domain-Logik aus `src/domain/*` |
+| `scripts/qa-encoding.ps1` | Zeichensatz- und Terminologie-Prüfung | prüft UTF-8, Mojibake und zentrale UI-Begriffe in Quell-, Dist- und Doku-Dateien | `src/*`, `dist/autodarts-local-tournament.user.js`, `docs/*`, `README.md` |
+| `scripts/qa-regelcheck.ps1` | fachlicher Regex-Check | prüft in `dist/*`, ob zentrale Regelmappings, KO-Logik und Terminologie im Bundle vorkommen | `dist/autodarts-local-tournament.user.js`, Domain-Logik aus `src/domain/*` |
 | `scripts/test-domain.ps1` | isolierter Domain-Harness | baut einen no-deps Test-Bundle für pure Domain-Logik und führt ihn im Headless-Browser aus | `build/domain-test-manifest.json`, `tests/test-harness.js`, `tests/domain-isolation.js`, `tests/unit-*.js` |
-| `scripts/test-runtime-contract.ps1` | Runtime-Contract-Test | lädt `dist/*` im Headless-Browser und prüft `window.__ATA_RUNTIME` plus `runSelfTests()` | `dist/autodarts-tournament-assistant.user.js`, `tests/contracts/*` |
-| `scripts/qa-build-discipline.ps1` | Build-Disziplin | prüft Placeholder-Nutzung, Versionseinbau und generierte Runtime-/Meta-Artefakte | `build/version.json`, `src/core/constants.js`, `dist/autodarts-tournament-assistant.user.js`, `dist/autodarts-tournament-assistant.meta.js` |
-| `installer/Autodarts Tournament Assistant Loader.user.js` | Loader-Skript, nicht App-Logik | lädt die veröffentlichte Dist-Datei remote, validiert sie, cached sie lokal und erzeugt den Menü-Einstieg | `dist/autodarts-tournament-assistant.user.js`, GitHub Raw URL, Tampermonkey GM APIs |
-| `dist/autodarts-tournament-assistant.user.js` | generiertes Auslieferungsartefakt | enthält das komplette Userscript als eine Datei; ist Loader-kompatibel und direkt installierbar | `scripts/build.ps1`, `installer/Autodarts Tournament Assistant Loader.user.js`, Browser/Tampermonkey |
-| `dist/autodarts-tournament-assistant.meta.js` | leichtgewichtiges Versionsartefakt | enthält nur den Userscript-Header für Update-Checks und `@updateURL` | `scripts/build.ps1`, `src/infra/update-check.js`, Tampermonkey/GitHub Raw |
+| `scripts/test-runtime-contract.ps1` | Runtime-Contract-Test | lädt `dist/*` im Headless-Browser und prüft `window.__ATA_RUNTIME` plus `runSelfTests()` | `dist/autodarts-local-tournament.user.js`, `tests/contracts/*` |
+| `scripts/qa-build-discipline.ps1` | Build-Disziplin | prüft Placeholder-Nutzung, Versionseinbau und generierte Runtime-/Meta-Artefakte | `package.json`, `src/core/constants.js`, `dist/autodarts-local-tournament.user.js`, `dist/autodarts-local-tournament.meta.js`, Legacy-Alias |
+| `installer/Autodarts Tournament Assistant Loader.user.js` | Loader-Skript (Legacy-Fallback, deprecated) | lädt die veröffentlichte Dist-Datei remote, validiert sie, cached sie lokal, zeigt Migrationshinweis und erzeugt den Menü-Einstieg | `dist/autodarts-tournament-assistant.user.js`, GitHub Raw URL, Tampermonkey GM APIs |
+| `dist/autodarts-local-tournament.user.js` | generiertes Auslieferungsartefakt (Standard) | enthält das komplette Userscript als eine Datei; direkt installierbar ohne Loader | `scripts/build-userscript.mjs`, Browser/Tampermonkey |
+| `dist/autodarts-local-tournament.meta.js` | leichtgewichtiges Versionsartefakt (Standard) | enthält nur den Userscript-Header für Update-Checks und `@updateURL` | `scripts/build-userscript.mjs`, `src/infra/update-check.js`, Tampermonkey/GitHub Raw |
+| `dist/autodarts-tournament-assistant.user.js` | Legacy-Alias-Artefakt | kompatibler Alias für bestehende Installationen und Loader-Fallback | `scripts/build-userscript.mjs`, `installer/Autodarts Tournament Assistant Loader.user.js` |
+| `dist/autodarts-tournament-assistant.meta.js` | Legacy-Alias-Meta-Artefakt | Header-Only Alias für bestehende Updatepfade | `scripts/build-userscript.mjs`, Tampermonkey |
 
 ### Tests
 
@@ -347,7 +356,7 @@ Die Tabellen unten beschreiben pro Datei:
 | `tests/unit-update-check.js` | Update-Check-Unit-Tests | prüft Versionsvergleich, Cache-Busting, Fallback und TTL ohne Netzabhängigkeit | `src/infra/update-check.js`, `tests/test-harness.js` |
 | `tests/unit-rules-config.js` | Rules-Unit-Tests | prüft pure Tie-Break- und Draw-Lock-Mutationen | `src/domain/rules-config.js`, `tests/test-harness.js` |
 | `tests/unit-standings-dra.js` | Standings-Unit-Tests | prüft H2H/Mini-Tabelle, Legacy-Profil und `playoff_required` | `src/domain/standings-dra.js`, `tests/test-harness.js` |
-| `tests/selftest-runtime.js` | Browser-Konsole-Helfer | ruft `window.__ATA_RUNTIME.runSelfTests()` auf und formatiert das Ergebnis für `console.table` | `src/app/diagnostics.js`, `dist/autodarts-tournament-assistant.user.js` |
+| `tests/selftest-runtime.js` | Browser-Konsole-Helfer | ruft `window.__ATA_RUNTIME.runSelfTests()` auf und formatiert das Ergebnis für `console.table` | `src/app/diagnostics.js`, `dist/autodarts-local-tournament.user.js` |
 
 ### Core
 
@@ -449,7 +458,7 @@ Hier liegt die eigentliche Turnierlogik. Wenn sich eine fachliche Regel ändert,
 
 ### `src/ui/styles/main.css`
 - enthält das komplette Shadow-DOM-Styling der UI
-- wird nicht separat ausgeliefert, sondern durch `scripts/build.ps1` in das Bundle eingebettet
+- wird nicht separat ausgeliefert, sondern durch `scripts/build-userscript.mjs` in das Bundle eingebettet
 - ist deshalb Quellmaterial, aber kein eigener Runtime-Ladepunkt
 
 ### `tests/fixtures/*.json`
@@ -473,7 +482,7 @@ Assets erklären das Produkt und speisen zum Teil den Build, tragen aber keine L
 
 ## Pflegehinweise für künftige Änderungen
 - Neue Quellmodule immer auch in `build/manifest.json` eintragen. Die Datei existiert nicht nur dokumentarisch, sondern steuert die tatsächliche Bundle-Reihenfolge.
-- `dist/autodarts-tournament-assistant.user.js` und `dist/autodarts-tournament-assistant.meta.js` nicht manuell pflegen. Änderungen gehören in `src/*`, `src/ui/styles/main.css` oder `assets/*`.
+- `dist/autodarts-local-tournament.user.js` / `.meta.js` sowie die Legacy-Aliase in `dist/autodarts-tournament-assistant.*` nicht manuell pflegen. Änderungen gehören in `src/*`, `src/ui/styles/main.css` oder `assets/*`.
 - Neue Fachregeln zuerst in `src/domain/*` verorten, nicht in Render-Dateien oder API-Schichten.
 - Neue Persistenzfelder immer mit Blick auf `src/data/normalization.js` und `src/data/migration.js` einführen.
 - Wenn UI-Hilfelinks, Regelbegriffe oder Doku-Einstiegspunkte geändert werden, auch `README.md`, `docs/architecture.md` und gegebenenfalls `docs/dra-regeln-gui.md` mitprüfen.

--- a/docs/refactor-guide.md
+++ b/docs/refactor-guide.md
@@ -1,12 +1,16 @@
 ﻿# Refactor Guide
 
 ## Ziel
-Modulare Pflege des Userscripts ohne npm/Node mit reproduzierbarem Build.
+Modulare Pflege des Userscripts mit reproduzierbarem Build und klarer Dist-Distribution.
 
 ## Arbeitsweise
 1. Änderungen in `src/*` durchführen.
-2. Versionsquelle bei Releases in `build/version.json` pflegen.
+2. Versionsquelle bei Releases in `package.json` pflegen.
 2. Build ausführen:
+```powershell
+npm run build
+```
+Optional kompatibel:
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts/build.ps1
 ```
@@ -16,6 +20,8 @@ powershell -ExecutionPolicy Bypass -File scripts/test-domain.ps1
 ```
 4. QA ausführen:
 ```powershell
+npm run check:syntax
+npm test
 powershell -ExecutionPolicy Bypass -File scripts/qa.ps1
 ```
 

--- a/installer/Autodarts Tournament Assistant Loader.user.js
+++ b/installer/Autodarts Tournament Assistant Loader.user.js
@@ -2,7 +2,7 @@
 // @name         Autodarts Tournament Assistant Loader
 // @namespace    https://github.com/thomasasen/autodarts_local_tournament
 // @version      0.1.4
-// @description  Loads the latest Autodarts Tournament Assistant userscript with cache fallback.
+// @description  Legacy loader (deprecated): loads ATA runtime from GitHub with cache fallback and migration hint.
 // @author       Thomas Asen
 // @license      MIT
 // @match        *://play.autodarts.io/*
@@ -11,7 +11,6 @@
 // @grant        GM_setValue
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
-// @connect      api.autodarts.io
 // @downloadURL  https://github.com/thomasasen/autodarts_local_tournament/raw/refs/heads/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js
 // @updateURL    https://github.com/thomasasen/autodarts_local_tournament/raw/refs/heads/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js
 // ==/UserScript==
@@ -23,9 +22,12 @@
   const RUNTIME_GUARD_KEY = "__ATA_RUNTIME_BOOTSTRAPPED";
   const CACHE_CODE_KEY = "ata:loader:cache:code:v1";
   const CACHE_META_KEY = "ata:loader:cache:meta:v1";
+  const DEPRECATION_NOTICE_KEY = "ata:loader:deprecation-notice-seen:v1";
+  const DEPRECATION_NOTICE_ID = "ata-loader-deprecation-notice";
   const REQUEST_TIMEOUT_MS = 10_000;
 
   const REMOTE_SOURCE_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js";
+  const NEW_INSTALLER_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js";
 
   const MENU_ITEM_ID = "ata-loader-menu-item";
   const MENU_LABEL = "xLokales Turnier";
@@ -103,6 +105,124 @@
     } catch (_) {
       // Ignore localStorage write errors.
     }
+  }
+
+  function createDeprecationNotice(onDismiss) {
+    const notice = document.createElement("div");
+    notice.id = DEPRECATION_NOTICE_ID;
+    notice.setAttribute("role", "status");
+    notice.setAttribute("aria-live", "polite");
+    notice.style.position = "fixed";
+    notice.style.left = "12px";
+    notice.style.right = "12px";
+    notice.style.bottom = "12px";
+    notice.style.maxWidth = "760px";
+    notice.style.margin = "0 auto";
+    notice.style.zIndex = "2147483647";
+    notice.style.background = "#152643";
+    notice.style.color = "#f5f7ff";
+    notice.style.border = "1px solid rgba(255,255,255,0.2)";
+    notice.style.borderRadius = "10px";
+    notice.style.boxShadow = "0 16px 36px rgba(0,0,0,0.35)";
+    notice.style.padding = "12px 14px";
+    notice.style.fontFamily = "Segoe UI, Tahoma, Arial, sans-serif";
+    notice.style.fontSize = "13px";
+    notice.style.lineHeight = "1.35";
+
+    const message = document.createElement("div");
+    message.textContent = "Der ATA Loader ist veraltet (deprecated), wird nicht weiter gepflegt und wird in Zukunft aus dem Repository entfernt. Danach funktionieren Loader-Updates nicht mehr zuverlässig. Bitte auf den neuen direkten Dist-Installer wechseln.";
+    notice.appendChild(message);
+
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.flexWrap = "wrap";
+    actions.style.gap = "8px";
+    actions.style.marginTop = "10px";
+
+    const switchButton = document.createElement("button");
+    switchButton.type = "button";
+    switchButton.textContent = "Zum neuen Installer";
+    switchButton.style.border = "1px solid rgba(255,255,255,0.3)";
+    switchButton.style.background = "#1f73c9";
+    switchButton.style.color = "#ffffff";
+    switchButton.style.padding = "6px 10px";
+    switchButton.style.borderRadius = "7px";
+    switchButton.style.cursor = "pointer";
+    switchButton.addEventListener("click", () => {
+      try {
+        window.open(NEW_INSTALLER_URL, "_blank", "noopener,noreferrer");
+      } catch (_) {
+        // Ignore window.open failures.
+      }
+      onDismiss("switch");
+    });
+
+    const laterButton = document.createElement("button");
+    laterButton.type = "button";
+    laterButton.textContent = "Später";
+    laterButton.style.border = "1px solid rgba(255,255,255,0.3)";
+    laterButton.style.background = "transparent";
+    laterButton.style.color = "#ffffff";
+    laterButton.style.padding = "6px 10px";
+    laterButton.style.borderRadius = "7px";
+    laterButton.style.cursor = "pointer";
+    laterButton.addEventListener("click", () => onDismiss("dismiss"));
+
+    actions.appendChild(switchButton);
+    actions.appendChild(laterButton);
+    notice.appendChild(actions);
+    return notice;
+  }
+
+  function mountDeprecationNotice(onDismiss) {
+    if (document.getElementById(DEPRECATION_NOTICE_ID)) {
+      return;
+    }
+    if (!document.body) {
+      return;
+    }
+    const notice = createDeprecationNotice(onDismiss);
+    document.body.appendChild(notice);
+  }
+
+  async function showDeprecationBannerOnce() {
+    const alreadySeen = Boolean(await readStore(DEPRECATION_NOTICE_KEY, false));
+    if (alreadySeen) {
+      return;
+    }
+
+    warn("Legacy loader is deprecated. Please migrate to dist/autodarts-local-tournament.user.js.");
+
+    let dismissed = false;
+    const dismiss = async (reason) => {
+      if (dismissed) {
+        return;
+      }
+      dismissed = true;
+      await writeStore(DEPRECATION_NOTICE_KEY, true);
+      const existing = document.getElementById(DEPRECATION_NOTICE_ID);
+      if (existing) {
+        existing.remove();
+      }
+      log(`Deprecation notice acknowledged (${reason}).`);
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", () => {
+        mountDeprecationNotice((reason) => {
+          dismiss(reason).catch((errorValue) => {
+            warn("Failed to persist deprecation notice state.", errorValue);
+          });
+        });
+      }, { once: true });
+      return;
+    }
+
+    mountDeprecationNotice((reason) => {
+      dismiss(reason).catch((errorValue) => {
+        warn("Failed to persist deprecation notice state.", errorValue);
+      });
+    });
   }
 
   function requestText(url) {
@@ -700,4 +820,7 @@
   });
 
   initUiSyncLoop();
+  showDeprecationBannerOnce().catch((unexpectedError) => {
+    warn("Deprecation notice failed.", unexpectedError);
+  });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,500 @@
+{
+  "name": "autodarts-local-tournament",
+  "version": "0.3.5",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "autodarts-local-tournament",
+      "version": "0.3.5",
+      "license": "MIT",
+      "devDependencies": {
+        "esbuild": "^0.25.12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+﻿{
+  "name": "autodarts-local-tournament",
+  "version": "0.3.5",
+  "description": "Local tournament manager userscript for play.autodarts.io",
+  "type": "module",
+  "scripts": {
+    "build": "node ./scripts/build-userscript.mjs",
+    "build:userscript": "node ./scripts/build-userscript.mjs",
+    "check:syntax": "node ./scripts/check-syntax.mjs",
+    "test": "node ./scripts/run-tests.mjs",
+    "verify": "npm run build && npm run test && powershell -ExecutionPolicy Bypass -File scripts/qa.ps1"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "esbuild": "^0.25.12"
+  }
+}

--- a/scripts/build-userscript.mjs
+++ b/scripts/build-userscript.mjs
@@ -1,0 +1,172 @@
+﻿import { build } from "esbuild";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const distDir = path.join(repoRoot, "dist");
+
+const packageJsonPath = path.join(repoRoot, "package.json");
+const manifestPath = path.join(repoRoot, "build", "manifest.json");
+const cssPath = path.join(repoRoot, "src", "ui", "styles", "main.css");
+const logoPath = path.join(repoRoot, "assets", "pdc_logo.png");
+
+const canonicalBaseName = "autodarts-local-tournament";
+const legacyBaseName = "autodarts-tournament-assistant";
+
+const repositoryBaseUrl =
+  "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist";
+
+const canonicalUrls = Object.freeze({
+  download: `${repositoryBaseUrl}/${canonicalBaseName}.user.js`,
+  update: `${repositoryBaseUrl}/${canonicalBaseName}.meta.js`,
+});
+
+const legacyUrls = Object.freeze({
+  download: `${repositoryBaseUrl}/${legacyBaseName}.user.js`,
+  update: `${repositoryBaseUrl}/${legacyBaseName}.meta.js`,
+});
+
+function normalizeSourceChunk(text) {
+  return String(text || "")
+    .replace(/^\uFEFF/, "")
+    .replace(/^\s*\/\/ Auto-generated module split from dist source\.\r?\n/, "")
+    .trimEnd();
+}
+
+function createUserscriptHeader({ version, downloadUrl, updateUrl }) {
+  return `// ==UserScript==\n// @name         Autodarts Tournament Assistant\n// @namespace    https://github.com/thomasasen/autodarts_local_tournament\n// @version      ${version}\n// @description  Local tournament manager for play.autodarts.io (KO, Liga, Gruppen + KO)\n// @author       Thomas Asen\n// @license      MIT\n// @match        *://play.autodarts.io/*\n// @run-at       document-start\n// @grant        GM_getValue\n// @grant        GM_setValue\n// @grant        GM_xmlhttpRequest\n// @connect      api.autodarts.io\n// @downloadURL  ${downloadUrl}\n// @updateURL    ${updateUrl}\n// ==/UserScript==\n`;
+}
+
+function stripUserscriptHeader(sourceText) {
+  return String(sourceText || "").replace(/^\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==\s*/u, "");
+}
+
+function assertPlaceholderReplaced(text, placeholder, label) {
+  if (String(text || "").includes(placeholder)) {
+    throw new Error(`${label} placeholder replacement failed: ${placeholder}`);
+  }
+}
+
+function toAbsoluteRepoPath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+async function readPackageVersion() {
+  const packageJsonRaw = (await readFile(packageJsonPath, "utf8")).replace(/^\uFEFF/, "");
+  const packageJson = JSON.parse(packageJsonRaw);
+  const version = String(packageJson.version || "").trim();
+  if (!version) {
+    throw new Error("package.json is missing a valid version.");
+  }
+  return version;
+}
+
+async function readManifestFiles() {
+  const manifestRaw = (await readFile(manifestPath, "utf8")).replace(/^\uFEFF/, "");
+  const manifest = JSON.parse(manifestRaw);
+  const files = Array.isArray(manifest.files) ? manifest.files : [];
+  if (!files.length) {
+    throw new Error("build/manifest.json does not contain files.");
+  }
+  return files;
+}
+
+async function readBundleSource() {
+  const manifestFiles = await readManifestFiles();
+  const parts = [];
+
+  for (const relativeFile of manifestFiles) {
+    const fullPath = toAbsoluteRepoPath(relativeFile);
+    const raw = await readFile(fullPath, "utf8");
+    parts.push(normalizeSourceChunk(raw));
+  }
+
+  return `${parts.join("\n\n")}\n`;
+}
+
+async function replaceBundlePlaceholders(source, version) {
+  const cssRaw = await readFile(cssPath, "utf8");
+  const cssEscaped = cssRaw.trimEnd().replaceAll("`", "``").replaceAll("${", "\\${");
+
+  const logoRaw = await readFile(logoPath);
+  const logoDataUri = `data:image/png;base64,${logoRaw.toString("base64")}`;
+  const logoEscaped = logoDataUri.replaceAll("`", "``").replaceAll("${", "\\${");
+
+  let bundle = String(source || "");
+  bundle = bundle.replaceAll("__ATA_APP_VERSION__", version);
+  bundle = bundle.replaceAll("__ATA_UI_MAIN_CSS__", cssEscaped);
+  bundle = bundle.replaceAll("__ATA_PDC_LOGO_DATA_URI__", logoEscaped);
+
+  assertPlaceholderReplaced(bundle, "__ATA_APP_VERSION__", "Version");
+  assertPlaceholderReplaced(bundle, "__ATA_UI_MAIN_CSS__", "CSS");
+  assertPlaceholderReplaced(bundle, "__ATA_PDC_LOGO_DATA_URI__", "Logo");
+
+  return stripUserscriptHeader(bundle).replace(/\r\n/g, "\n");
+}
+
+async function transpileBundle(sourceWithoutHeader) {
+  const result = await build({
+    stdin: {
+      contents: sourceWithoutHeader,
+      sourcefile: "autodarts-runtime-input.js",
+      resolveDir: repoRoot,
+      loader: "js",
+    },
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: ["chrome100", "firefox100"],
+    write: false,
+    charset: "utf8",
+    legalComments: "none",
+  });
+
+  const output = result.outputFiles?.[0]?.text;
+  if (!output) {
+    throw new Error("esbuild did not produce output.");
+  }
+
+  return output.replace(/\r\n/g, "\n").trimEnd() + "\n";
+}
+
+async function writeVariant({ baseName, urls, version, transpiledBody }) {
+  const header = createUserscriptHeader({
+    version,
+    downloadUrl: urls.download,
+    updateUrl: urls.update,
+  });
+
+  const userScriptPath = path.join(distDir, `${baseName}.user.js`);
+  const metaPath = path.join(distDir, `${baseName}.meta.js`);
+
+  await writeFile(userScriptPath, `${header}\n${transpiledBody}`, "utf8");
+  await writeFile(metaPath, `${header}\n`, "utf8");
+}
+
+const version = await readPackageVersion();
+const source = await readBundleSource();
+const preparedSource = await replaceBundlePlaceholders(source, version);
+const transpiledBody = await transpileBundle(preparedSource);
+
+await mkdir(distDir, { recursive: true });
+
+await writeVariant({
+  baseName: canonicalBaseName,
+  urls: canonicalUrls,
+  version,
+  transpiledBody,
+});
+
+await writeVariant({
+  baseName: legacyBaseName,
+  urls: legacyUrls,
+  version,
+  transpiledBody,
+});
+
+console.log(
+  `Userscript build successful: dist/${canonicalBaseName}.user.js, dist/${canonicalBaseName}.meta.js (+ legacy aliases).`
+);

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,11 +1,4 @@
-param(
-  [string]$ManifestPath = "build/manifest.json",
-  [string]$VersionPath = "build/version.json",
-  [string]$CssPath = "src/ui/styles/main.css",
-  [string]$LogoPath = "assets/pdc_logo.png",
-  [string]$OutputPath = "dist/autodarts-tournament-assistant.user.js",
-  [string]$OutputMetaPath = "dist/autodarts-tournament-assistant.meta.js"
-)
+﻿param()
 
 $ErrorActionPreference = "Stop"
 
@@ -15,92 +8,14 @@ function Resolve-RepoPath([string]$RelativePath) {
   return (Join-Path $repoRoot $RelativePath)
 }
 
-$manifestFull = Resolve-RepoPath $ManifestPath
-$versionFull = Resolve-RepoPath $VersionPath
-$cssFull = Resolve-RepoPath $CssPath
-$logoFull = Resolve-RepoPath $LogoPath
-$outputFull = Resolve-RepoPath $OutputPath
-$outputMetaFull = Resolve-RepoPath $OutputMetaPath
-
-if (-not (Test-Path $manifestFull)) {
-  throw "Manifest not found: $manifestFull"
-}
-if (-not (Test-Path $versionFull)) {
-  throw "Version file not found: $versionFull"
-}
-if (-not (Test-Path $cssFull)) {
-  throw "CSS file not found: $cssFull"
-}
-if (-not (Test-Path $logoFull)) {
-  throw "Logo file not found: $logoFull"
+$buildScript = Resolve-RepoPath "scripts/build-userscript.mjs"
+if (-not (Test-Path $buildScript)) {
+  throw "Build script not found: $buildScript"
 }
 
-$manifest = Get-Content $manifestFull -Raw -Encoding utf8 | ConvertFrom-Json
-$versionConfig = Get-Content $versionFull -Raw -Encoding utf8 | ConvertFrom-Json
-if (-not $manifest.files -or $manifest.files.Count -eq 0) {
-  throw "Manifest contains no files."
-}
-$appVersion = [string]$versionConfig.appVersion
-if (-not $appVersion) {
-  throw "Version file contains no appVersion."
+$nodeResult = & node $buildScript
+if ($LASTEXITCODE -ne 0) {
+  throw "Build failed."
 }
 
-$parts = New-Object System.Collections.Generic.List[string]
-foreach ($relativeFile in $manifest.files) {
-  $fullFile = Resolve-RepoPath $relativeFile
-  if (-not (Test-Path $fullFile)) {
-    throw "Source file not found: $relativeFile"
-  }
-  $raw = Get-Content $fullFile -Raw -Encoding utf8
-  $raw = $raw -replace '^\s*// Auto-generated module split from dist source\.\r?\n', ''
-  $parts.Add($raw.TrimEnd())
-}
-
-$bundle = ($parts -join "`n`n") + "`n"
-
-$cssRaw = Get-Content $cssFull -Raw -Encoding utf8
-$cssRaw = $cssRaw.Trim("`r", "`n")
-$cssEscaped = $cssRaw.Replace('`', '``').Replace('${', '\${')
-$bundle = $bundle.Replace('__ATA_APP_VERSION__', $appVersion)
-$bundle = $bundle.Replace('__ATA_UI_MAIN_CSS__', $cssEscaped)
-$logoBytes = [System.IO.File]::ReadAllBytes($logoFull)
-$logoBase64 = [Convert]::ToBase64String($logoBytes)
-$logoDataUri = "data:image/png;base64,$logoBase64"
-$logoEscaped = $logoDataUri.Replace('`', '``').Replace('${', '\${')
-$bundle = $bundle.Replace('__ATA_PDC_LOGO_DATA_URI__', $logoEscaped)
-
-if ($bundle.Contains('__ATA_UI_MAIN_CSS__')) {
-  throw "CSS placeholder replacement failed."
-}
-if ($bundle.Contains('__ATA_PDC_LOGO_DATA_URI__')) {
-  throw "Logo placeholder replacement failed."
-}
-if ($bundle.Contains('__ATA_APP_VERSION__')) {
-  throw "Version placeholder replacement failed."
-}
-
-$bundle = $bundle -replace "`r`n", "`n"
-
-Set-Content -Path $outputFull -Value $bundle -Encoding utf8
-
-$headerMatch = [regex]::Match($bundle, '(?s)^// ==UserScript==.*?// ==/UserScript==')
-if (-not $headerMatch.Success) {
-  throw "Userscript header extraction failed."
-}
-$metaBundle = ($headerMatch.Value.TrimEnd() + "`n")
-Set-Content -Path $outputMetaFull -Value $metaBundle -Encoding utf8
-
-if (-not (Test-Path $outputFull)) {
-  throw "Output write failed: $outputFull"
-}
-if (-not (Get-Content $outputFull -Raw -Encoding utf8).Contains("// ==UserScript==")) {
-  throw "Output is missing userscript header."
-}
-if (-not (Test-Path $outputMetaFull)) {
-  throw "Meta output write failed: $outputMetaFull"
-}
-if (-not (Get-Content $outputMetaFull -Raw -Encoding utf8).Contains("// ==UserScript==")) {
-  throw "Meta output is missing userscript header."
-}
-
-Write-Host "Build successful: $OutputPath (+ $OutputMetaPath)"
+Write-Host $nodeResult

--- a/scripts/check-syntax.mjs
+++ b/scripts/check-syntax.mjs
@@ -1,0 +1,177 @@
+﻿import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+const scanRoots = ["src", "scripts", "installer", "tests", "dist"];
+const skipDirectories = new Set(["node_modules", ".git", ".tmp-domain-tests", ".tmp-runtime-contract"]);
+const jsExtensions = new Set([".js", ".mjs", ".cjs"]);
+
+const jsonFiles = [
+  "package.json",
+  "package-lock.json",
+  "build/manifest.json",
+  "build/domain-test-manifest.json",
+  "build/version.json",
+];
+
+function normalizeSourceChunk(text) {
+  return String(text || "")
+    .replace(/^\uFEFF/, "")
+    .replace(/^\s*\/\/ Auto-generated module split from dist source\.\r?\n/, "")
+    .trimEnd();
+}
+
+async function collectJavaScriptFiles(rootDirectory) {
+  const absoluteRoot = path.join(repoRoot, rootDirectory);
+  let entries;
+  try {
+    entries = await readdir(absoluteRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (skipDirectories.has(entry.name)) {
+        continue;
+      }
+      const nestedDirectory = path.join(rootDirectory, entry.name);
+      files.push(...(await collectJavaScriptFiles(nestedDirectory)));
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const extension = path.extname(entry.name).toLowerCase();
+    if (!jsExtensions.has(extension)) {
+      continue;
+    }
+
+    files.push(path.join(rootDirectory, entry.name));
+  }
+
+  return files;
+}
+
+function assertNodeSyntax(absoluteFilePath, label) {
+  const result = spawnSync(process.execPath, ["--check", absoluteFilePath], {
+    cwd: repoRoot,
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    const details = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(details || `node --check failed for ${label}`);
+  }
+}
+
+async function assertManifestBundleSyntax() {
+  const manifestRaw = (await readFile(path.join(repoRoot, "build", "manifest.json"), "utf8")).replace(/^\uFEFF/, "");
+  const manifest = JSON.parse(manifestRaw);
+  const files = Array.isArray(manifest.files) ? manifest.files : [];
+
+  if (!files.length) {
+    throw new Error("build/manifest.json does not contain files for source syntax check.");
+  }
+
+  const parts = [];
+  for (const relativeFilePath of files) {
+    const absolutePath = path.join(repoRoot, relativeFilePath);
+    const raw = await readFile(absolutePath, "utf8");
+    parts.push(normalizeSourceChunk(raw));
+  }
+
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), "ata-syntax-"));
+  const tempFilePath = path.join(tempDirectory, "manifest-bundle.js");
+
+  try {
+    await writeFile(tempFilePath, `${parts.join("\n\n")}\n`, "utf8");
+    assertNodeSyntax(tempFilePath, "manifest bundle");
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+async function assertUtf8(relativeFilePath) {
+  const absoluteFilePath = path.join(repoRoot, relativeFilePath);
+  const raw = await readFile(absoluteFilePath);
+  utf8Decoder.decode(raw);
+}
+
+async function assertJsonSyntax(relativeFilePath) {
+  const absoluteFilePath = path.join(repoRoot, relativeFilePath);
+  const jsonRaw = (await readFile(absoluteFilePath, "utf8")).replace(/^\uFEFF/, "");
+  JSON.parse(jsonRaw);
+}
+
+const jsFiles = (
+  await Promise.all(scanRoots.map((rootDirectory) => collectJavaScriptFiles(rootDirectory)))
+)
+  .flat()
+  .sort((left, right) => left.localeCompare(right));
+
+if (!jsFiles.length) {
+  throw new Error("No JavaScript files found for syntax validation.");
+}
+
+const failures = [];
+
+for (const relativeFilePath of jsFiles) {
+  try {
+    await assertUtf8(relativeFilePath);
+    const isManifestSplitSource = relativeFilePath.startsWith("src/") || relativeFilePath.startsWith(`src${path.sep}`);
+    if (!isManifestSplitSource) {
+      assertNodeSyntax(path.join(repoRoot, relativeFilePath), relativeFilePath);
+    }
+  } catch (error) {
+    failures.push({ file: relativeFilePath, error });
+  }
+}
+
+try {
+  await assertManifestBundleSyntax();
+} catch (error) {
+  failures.push({ file: "build/manifest.json -> bundled src syntax", error });
+}
+
+for (const relativeFilePath of jsonFiles) {
+  const absolutePath = path.join(repoRoot, relativeFilePath);
+  try {
+    await readFile(absolutePath);
+    await assertJsonSyntax(relativeFilePath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      continue;
+    }
+    failures.push({ file: relativeFilePath, error });
+  }
+}
+
+if (failures.length) {
+  console.error(`Syntax check failed for ${failures.length} file(s):`);
+  for (const failure of failures) {
+    const message = failure.error instanceof Error ? failure.error.message : String(failure.error);
+    console.error(`- ${failure.file}`);
+    console.error(`  ${message}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Syntax check passed: ${jsFiles.length} JavaScript file(s) + bundled src syntax + ${jsonFiles.length} JSON target(s).`
+);

--- a/scripts/qa-build-discipline.ps1
+++ b/scripts/qa-build-discipline.ps1
@@ -1,4 +1,4 @@
-param()
+﻿param()
 
 $ErrorActionPreference = "Stop"
 
@@ -8,15 +8,17 @@ function Resolve-RepoPath([string]$RelativePath) {
   return (Join-Path $repoRoot $RelativePath)
 }
 
-$versionPath = Resolve-RepoPath "build/version.json"
+$packagePath = Resolve-RepoPath "package.json"
 $constantsPath = Resolve-RepoPath "src/core/constants.js"
-$distPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
-$metaPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.meta.js"
+$canonicalDistPath = Resolve-RepoPath "dist/autodarts-local-tournament.user.js"
+$canonicalMetaPath = Resolve-RepoPath "dist/autodarts-local-tournament.meta.js"
+$legacyDistPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
+$legacyMetaPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.meta.js"
 
-$versionConfig = Get-Content $versionPath -Raw -Encoding utf8 | ConvertFrom-Json
-$appVersion = [string]$versionConfig.appVersion
+$packageConfig = Get-Content $packagePath -Raw -Encoding utf8 | ConvertFrom-Json
+$appVersion = [string]$packageConfig.version
 if (-not $appVersion) {
-  throw "Build discipline QA failed: appVersion missing in build/version.json."
+  throw "Build discipline QA failed: version missing in package.json."
 }
 
 $constants = Get-Content $constantsPath -Raw -Encoding utf8
@@ -24,25 +26,43 @@ if ($constants -notmatch '__ATA_APP_VERSION__') {
   throw "Build discipline QA failed: src/core/constants.js must use __ATA_APP_VERSION__ placeholder."
 }
 
-$dist = Get-Content $distPath -Raw -Encoding utf8
-$meta = Get-Content $metaPath -Raw -Encoding utf8
-if ($dist -match '__ATA_APP_VERSION__') {
-  throw "Build discipline QA failed: unresolved __ATA_APP_VERSION__ placeholder found in dist."
+$artifacts = @(
+  @{ Label = "canonical dist"; Path = $canonicalDistPath },
+  @{ Label = "canonical meta"; Path = $canonicalMetaPath },
+  @{ Label = "legacy dist"; Path = $legacyDistPath },
+  @{ Label = "legacy meta"; Path = $legacyMetaPath }
+)
+
+foreach ($artifact in $artifacts) {
+  if (-not (Test-Path $artifact.Path)) {
+    throw "Build discipline QA failed: missing artifact $($artifact.Label) -> $($artifact.Path)"
+  }
+  $content = Get-Content $artifact.Path -Raw -Encoding utf8
+  if ($content -match '__ATA_APP_VERSION__') {
+    throw "Build discipline QA failed: unresolved __ATA_APP_VERSION__ placeholder found in $($artifact.Label)."
+  }
+  if ($content -notmatch "@version\s+$([regex]::Escape($appVersion))") {
+    throw "Build discipline QA failed: $($artifact.Label) version does not match package.json."
+  }
 }
-if ($dist -notmatch "@version\s+$([regex]::Escape($appVersion))") {
-  throw "Build discipline QA failed: dist userscript header version does not match build/version.json."
+
+$canonicalDist = Get-Content $canonicalDistPath -Raw -Encoding utf8
+if ($canonicalDist -notmatch "const APP_VERSION = `"$([regex]::Escape($appVersion))`";") {
+  throw "Build discipline QA failed: canonical dist APP_VERSION does not match package.json."
 }
-if ($dist -notmatch "const APP_VERSION = `"$([regex]::Escape($appVersion))`";") {
-  throw "Build discipline QA failed: dist APP_VERSION does not match build/version.json."
+if ($canonicalDist -notmatch "@downloadURL\s+https://raw\.githubusercontent\.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament\.user\.js") {
+  throw "Build discipline QA failed: canonical dist downloadURL is incorrect."
 }
-if ($meta -match '__ATA_APP_VERSION__') {
-  throw "Build discipline QA failed: unresolved __ATA_APP_VERSION__ placeholder found in meta."
+if ($canonicalDist -notmatch "@updateURL\s+https://raw\.githubusercontent\.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament\.meta\.js") {
+  throw "Build discipline QA failed: canonical dist updateURL is incorrect."
 }
-if ($meta -notmatch "@version\s+$([regex]::Escape($appVersion))") {
-  throw "Build discipline QA failed: meta userscript header version does not match build/version.json."
+
+$legacyDist = Get-Content $legacyDistPath -Raw -Encoding utf8
+if ($legacyDist -notmatch "@downloadURL\s+https://raw\.githubusercontent\.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant\.user\.js") {
+  throw "Build discipline QA failed: legacy dist downloadURL is incorrect."
 }
-if ($meta -notmatch "@updateURL\s+https://raw\.githubusercontent\.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant\.meta\.js") {
-  throw "Build discipline QA failed: meta updateURL is not pointing to dist/autodarts-tournament-assistant.meta.js."
+if ($legacyDist -notmatch "@updateURL\s+https://raw\.githubusercontent\.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant\.meta\.js") {
+  throw "Build discipline QA failed: legacy dist updateURL is incorrect."
 }
 
 Write-Host "Build discipline QA successful."

--- a/scripts/qa-encoding.ps1
+++ b/scripts/qa-encoding.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
   [string[]]$Paths = @("src", "dist", "docs", "README.md")
 )
 
@@ -22,7 +22,7 @@ foreach ($path in $Paths) {
   $item = Get-Item $full
   if ($item.PSIsContainer) {
     Get-ChildItem $full -Recurse -File | ForEach-Object {
-      if ($_.Extension -in @('.js', '.ps1', '.md', '.json', '.css')) {
+      if ($_.Extension -in @('.js', '.ps1', '.md', '.json', '.css', '.mjs')) {
         $filesToCheck.Add($_.FullName)
       }
     }
@@ -44,10 +44,10 @@ foreach ($file in $filesToCheck) {
   }
 }
 
-$distPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
+$distPath = Resolve-RepoPath "dist/autodarts-local-tournament.user.js"
 if (Test-Path $distPath) {
   $dist = Get-Content $distPath -Raw -Encoding utf8
-  if (-not ($dist -match 'N(\\u00e4|\\x{00E4})chstes Match')) {
+  if (-not ($dist -match 'N.{1}chstes Match')) {
     $errors += "Required UI term 'Nächstes Match' missing (escaped or UTF-8)."
   }
   if (-not ($dist -match 'Freilos\s*\(Bye\)')) {

--- a/scripts/qa-regelcheck.ps1
+++ b/scripts/qa-regelcheck.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$DistPath = "dist/autodarts-tournament-assistant.user.js"
+  [string]$DistPath = "dist/autodarts-local-tournament.user.js"
 )
 
 $ErrorActionPreference = "Stop"

--- a/scripts/qa.ps1
+++ b/scripts/qa.ps1
@@ -1,4 +1,4 @@
-param()
+﻿param()
 
 $ErrorActionPreference = "Stop"
 
@@ -15,7 +15,8 @@ $encodingScript = Resolve-RepoPath "scripts/qa-encoding.ps1"
 $rulesScript = Resolve-RepoPath "scripts/qa-regelcheck.ps1"
 $domainTestScript = Resolve-RepoPath "scripts/test-domain.ps1"
 $runtimeContractScript = Resolve-RepoPath "scripts/test-runtime-contract.ps1"
-$distPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
+$canonicalDistPath = Resolve-RepoPath "dist/autodarts-local-tournament.user.js"
+$legacyDistPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
 
 & $buildScript
 & $architectureScript
@@ -25,15 +26,20 @@ $distPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
 & $runtimeContractScript
 & $buildDisciplineScript
 
-$dist = Get-Content $distPath -Raw -Encoding utf8
-if (-not ($dist -match 'runSelfTests')) {
-  throw "Smoke QA failed: runSelfTests not found in dist."
+$canonicalDist = Get-Content $canonicalDistPath -Raw -Encoding utf8
+$legacyDist = Get-Content $legacyDistPath -Raw -Encoding utf8
+
+if (-not ($canonicalDist -match 'runSelfTests')) {
+  throw "Smoke QA failed: runSelfTests not found in canonical dist."
 }
-if (-not ($dist -match 'STORAGE_SCHEMA_VERSION\s*=\s*4')) {
-  throw "Smoke QA failed: STORAGE_SCHEMA_VERSION=4 not found in dist."
+if (-not ($canonicalDist -match 'STORAGE_SCHEMA_VERSION\s*=\s*4')) {
+  throw "Smoke QA failed: STORAGE_SCHEMA_VERSION=4 not found in canonical dist."
 }
-if (-not ($dist -match 'function\s+standingsForMatches')) {
-  throw "Smoke QA failed: standingsForMatches not found in dist."
+if (-not ($canonicalDist -match 'function\s+standingsForMatches')) {
+  throw "Smoke QA failed: standingsForMatches not found in canonical dist."
+}
+if (-not ($legacyDist -match 'runSelfTests')) {
+  throw "Smoke QA failed: runSelfTests not found in legacy alias dist."
 }
 
 Write-Host "QA successful."

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,195 @@
+﻿import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const packageJsonPath = path.join(repoRoot, "package.json");
+const buildScriptPath = path.join(repoRoot, "scripts", "build-userscript.mjs");
+const syntaxCheckScriptPath = path.join(repoRoot, "scripts", "check-syntax.mjs");
+
+const canonicalBaseName = "autodarts-local-tournament";
+const legacyBaseName = "autodarts-tournament-assistant";
+
+const canonicalUrls = Object.freeze({
+  download:
+    "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js",
+  update:
+    "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.meta.js",
+});
+
+const legacyUrls = Object.freeze({
+  download:
+    "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js",
+  update:
+    "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.meta.js",
+});
+
+const requiredGrantSet = new Set(["GM_getValue", "GM_setValue", "GM_xmlhttpRequest"]);
+const requiredConnectSet = new Set(["api.autodarts.io"]);
+
+function runCommand(command, args, label) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${result.status}.`);
+  }
+}
+
+function runPowerShellScript(relativeScriptPath) {
+  const shell = process.platform === "win32" ? "powershell" : "pwsh";
+  runCommand(
+    shell,
+    ["-ExecutionPolicy", "Bypass", "-File", path.join(repoRoot, relativeScriptPath)],
+    relativeScriptPath
+  );
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function assertMatch(text, pattern, message) {
+  if (!pattern.test(text)) {
+    throw new Error(message);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function readUtf8(filePath) {
+  return readFileSync(filePath, "utf8").replace(/^\uFEFF/, "");
+}
+
+function extractHeader(text) {
+  const match = String(text || "").match(/^\/\/ ==UserScript==[\s\S]*?\/\/ ==\/UserScript==/u);
+  return match ? match[0] : "";
+}
+
+function collectHeaderEntries(header, key) {
+  const regex = new RegExp(`^\\/\\/\\s*@${escapeRegExp(key)}\\s+(.+)$`, "gmu");
+  const values = [];
+  for (const match of header.matchAll(regex)) {
+    values.push(String(match[1] || "").trim());
+  }
+  return values;
+}
+
+function assertUserscriptVariant({ variantLabel, userPath, metaPath, expectedUrls, packageVersion }) {
+  assert(existsSync(userPath), `${variantLabel}: missing userscript artifact ${path.basename(userPath)}`);
+  assert(existsSync(metaPath), `${variantLabel}: missing meta artifact ${path.basename(metaPath)}`);
+
+  const userScriptText = readUtf8(userPath);
+  const metaText = readUtf8(metaPath);
+
+  const userHeader = extractHeader(userScriptText);
+  const metaHeader = extractHeader(metaText);
+
+  assert(userHeader, `${variantLabel}: userscript header missing.`);
+  assert(metaHeader, `${variantLabel}: meta header missing.`);
+
+  assertMatch(userHeader, new RegExp(`@name\\s+Autodarts Tournament Assistant`), `${variantLabel}: @name missing or changed.`);
+  assertMatch(userHeader, new RegExp(`@namespace\\s+https://github\\.com/thomasasen/autodarts_local_tournament`), `${variantLabel}: @namespace missing or changed.`);
+  assertMatch(userHeader, new RegExp(`@version\\s+${escapeRegExp(packageVersion)}`), `${variantLabel}: @version not synced to package.json.`);
+  assertMatch(userHeader, /@description\s+Local tournament manager for play\.autodarts\.io/, `${variantLabel}: @description missing.`);
+  assertMatch(userHeader, /@author\s+Thomas Asen/, `${variantLabel}: @author missing.`);
+  assertMatch(userHeader, /@license\s+MIT/, `${variantLabel}: @license missing.`);
+  assertMatch(userHeader, /@match\s+\*:\/\/play\.autodarts\.io\/*/, `${variantLabel}: @match missing.`);
+  assertMatch(userHeader, /@run-at\s+document-start/, `${variantLabel}: @run-at missing.`);
+
+  assertMatch(userHeader, new RegExp(`@downloadURL\\s+${escapeRegExp(expectedUrls.download)}`), `${variantLabel}: @downloadURL mismatch.`);
+  assertMatch(userHeader, new RegExp(`@updateURL\\s+${escapeRegExp(expectedUrls.update)}`), `${variantLabel}: @updateURL mismatch.`);
+
+  assertMatch(metaHeader, new RegExp(`@version\\s+${escapeRegExp(packageVersion)}`), `${variantLabel} meta: @version mismatch.`);
+  assertMatch(metaHeader, new RegExp(`@downloadURL\\s+${escapeRegExp(expectedUrls.download)}`), `${variantLabel} meta: @downloadURL mismatch.`);
+  assertMatch(metaHeader, new RegExp(`@updateURL\\s+${escapeRegExp(expectedUrls.update)}`), `${variantLabel} meta: @updateURL mismatch.`);
+
+  assert(!userScriptText.includes("__ATA_APP_VERSION__"), `${variantLabel}: unresolved version placeholder in userscript.`);
+  assert(!metaText.includes("__ATA_APP_VERSION__"), `${variantLabel}: unresolved version placeholder in meta.`);
+
+  assertMatch(
+    userScriptText,
+    new RegExp(`const APP_VERSION = "${escapeRegExp(packageVersion)}";`),
+    `${variantLabel}: APP_VERSION constant not synced to package.json.`
+  );
+
+  const grants = new Set(collectHeaderEntries(userHeader, "grant"));
+  assert(grants.size === requiredGrantSet.size, `${variantLabel}: unexpected @grant count.`);
+  for (const grant of requiredGrantSet) {
+    assert(grants.has(grant), `${variantLabel}: missing @grant ${grant}.`);
+  }
+
+  const connectEntries = new Set(collectHeaderEntries(userHeader, "connect"));
+  assert(connectEntries.size === requiredConnectSet.size, `${variantLabel}: unexpected @connect count.`);
+  for (const connect of requiredConnectSet) {
+    assert(connectEntries.has(connect), `${variantLabel}: missing @connect ${connect}.`);
+  }
+
+  const sequenceMarkers = [
+    "const RUNTIME_GUARD_KEY = \"__ATA_RUNTIME_BOOTSTRAPPED\";",
+    "function addCleanup(fn)",
+    "function normalizeStoreShape(input)",
+    "function migrateStorage(rawValue)",
+    "async function loadPersistedStore()",
+    "function initEventBridge()",
+    "function setupRuntimeApi()",
+    "function installRouteHooks()",
+    "function renderShell()",
+    "async function init()",
+  ];
+
+  let previousIndex = -1;
+  for (const marker of sequenceMarkers) {
+    const markerIndex = userScriptText.indexOf(marker);
+    assert(markerIndex >= 0, `${variantLabel}: boot marker missing (${marker}).`);
+    assert(markerIndex > previousIndex, `${variantLabel}: boot marker order changed around (${marker}).`);
+    previousIndex = markerIndex;
+  }
+
+  assert(userScriptText.includes("window.dispatchEvent(new CustomEvent(READY_EVENT"), `${variantLabel}: READY_EVENT dispatch missing.`);
+  assert(userScriptText.includes("window[RUNTIME_GUARD_KEY] = true"), `${variantLabel}: runtime guard assignment missing.`);
+  assert(userScriptText.includes("window[RUNTIME_GLOBAL_KEY] = {"), `${variantLabel}: runtime public API missing.`);
+
+  assert(!userScriptText.includes("REMOTE_SOURCE_URL"), `${variantLabel}: main dist must not include loader remote-download runtime.`);
+  assert(!userScriptText.includes("executeWithCacheFallback"), `${variantLabel}: main dist must not include loader execution path.`);
+}
+
+runCommand(process.execPath, [syntaxCheckScriptPath], "syntax gate");
+runCommand(process.execPath, [buildScriptPath], "userscript build");
+
+const packageVersion = JSON.parse(readUtf8(packageJsonPath)).version;
+
+assertUserscriptVariant({
+  variantLabel: "canonical",
+  userPath: path.join(repoRoot, "dist", `${canonicalBaseName}.user.js`),
+  metaPath: path.join(repoRoot, "dist", `${canonicalBaseName}.meta.js`),
+  expectedUrls: canonicalUrls,
+  packageVersion,
+});
+
+assertUserscriptVariant({
+  variantLabel: "legacy-alias",
+  userPath: path.join(repoRoot, "dist", `${legacyBaseName}.user.js`),
+  metaPath: path.join(repoRoot, "dist", `${legacyBaseName}.meta.js`),
+  expectedUrls: legacyUrls,
+  packageVersion,
+});
+
+runPowerShellScript("scripts/test-domain.ps1");
+runPowerShellScript("scripts/test-runtime-contract.ps1");
+
+console.log("All tests passed: syntax, build artifacts, headers, boot-order checks, domain tests, runtime contract.");

--- a/scripts/test-domain.ps1
+++ b/scripts/test-domain.ps1
@@ -29,11 +29,8 @@ $manifest = Get-Content $manifestPath -Raw -Encoding utf8 | ConvertFrom-Json
 $browserPath = Get-BrowserPath
 $repoRoot = Resolve-RepoPath "."
 
-$tempRoot = Join-Path $repoRoot ".tmp-domain-tests"
-if (Test-Path $tempRoot) {
-  Remove-Item $tempRoot -Recurse -Force
-}
-New-Item -ItemType Directory -Path $tempRoot | Out-Null
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ata-domain-tests-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
 $htmlPath = Join-Path $tempRoot "domain-tests.html"
 
@@ -98,13 +95,26 @@ $bundleInline
 Set-Content -Path $htmlPath -Value $html -Encoding utf8
 
 $htmlUri = [System.Uri]::new((Resolve-Path $htmlPath).Path)
-$domOutput = & $browserPath `
-  --headless=new `
-  --disable-gpu `
-  --allow-file-access-from-files `
-  --virtual-time-budget=6000 `
-  --dump-dom `
-  $htmlUri.AbsoluteUri 2>&1 | Out-String
+$stdoutPath = Join-Path $tempRoot "domain-tests.stdout.txt"
+$stderrPath = Join-Path $tempRoot "domain-tests.stderr.txt"
+$arguments = @(
+  "--headless=new",
+  "--disable-gpu",
+  "--allow-file-access-from-files",
+  "--virtual-time-budget=6000",
+  "--dump-dom",
+  $htmlUri.AbsoluteUri
+)
+
+$process = Start-Process -FilePath $browserPath `
+  -ArgumentList $arguments `
+  -RedirectStandardOutput $stdoutPath `
+  -RedirectStandardError $stderrPath `
+  -PassThru `
+  -Wait `
+  -NoNewWindow
+
+$domOutput = Get-Content $stdoutPath -Raw -Encoding utf8
 
 if ($null -eq $domOutput) {
   throw "Headless-Browser lieferte keine DOM-Ausgabe."

--- a/scripts/test-runtime-contract.ps1
+++ b/scripts/test-runtime-contract.ps1
@@ -25,13 +25,10 @@ function Get-BrowserPath() {
 }
 
 $repoRoot = Resolve-RepoPath "."
-$tempRoot = Join-Path $repoRoot ".tmp-runtime-contract"
-if (Test-Path $tempRoot) {
-  Remove-Item $tempRoot -Recurse -Force
-}
-New-Item -ItemType Directory -Path $tempRoot | Out-Null
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ata-runtime-contract-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
-$distPath = Resolve-RepoPath "dist/autodarts-tournament-assistant.user.js"
+$distPath = Resolve-RepoPath "dist/autodarts-local-tournament.user.js"
 $runtimeContractPath = Resolve-RepoPath "tests/contracts/runtime-api-contract.js"
 $globalsContractPath = Resolve-RepoPath "tests/contracts/globals-contract.js"
 $htmlPath = Join-Path $tempRoot "runtime-contract.html"

--- a/skills/build-packaging/SKILL.md
+++ b/skills/build-packaging/SKILL.md
@@ -1,0 +1,26 @@
+﻿# SKILL.md
+
+## Name
+ATA Build & Packaging
+
+## Purpose
+Standardize reproducible dist generation with canonical + legacy userscript artifacts.
+
+## Commands
+```powershell
+npm install
+npm run build
+npm run check:syntax
+```
+
+## Expected outputs
+- `dist/autodarts-local-tournament.user.js`
+- `dist/autodarts-local-tournament.meta.js`
+- `dist/autodarts-tournament-assistant.user.js`
+- `dist/autodarts-tournament-assistant.meta.js`
+
+## Safety rules
+- Version source is only `package.json`.
+- Keep manifest order deterministic (`build/manifest.json`).
+- Never hand-edit dist outputs.
+- Do not change runtime logic while only fixing packaging.

--- a/skills/release-verification/SKILL.md
+++ b/skills/release-verification/SKILL.md
@@ -1,0 +1,26 @@
+﻿# SKILL.md
+
+## Name
+ATA Release Verification
+
+## Purpose
+Provide a repeatable release gate for build correctness and regression resistance.
+
+## Verification chain
+```powershell
+npm run build
+npm run check:syntax
+npm test
+powershell -ExecutionPolicy Bypass -File scripts/qa.ps1
+```
+
+## Manual checks
+1. Install canonical dist script in Tampermonkey.
+2. Validate single bootstrap and stable UI behavior.
+3. Validate update check path and metadata URLs.
+4. Validate legacy loader remains installable and shows migration hint.
+
+## Rollback readiness
+- Keep previous dist artifact accessible.
+- Keep legacy loader available until explicit removal decision.
+- Document rollback steps in release notes.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -11,11 +11,9 @@
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @grant        GM_xmlhttpRequest
-// @connect      cdn.jsdelivr.net
-// @connect      raw.githubusercontent.com
 // @connect      api.autodarts.io
-// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js
-// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.meta.js
+// @downloadURL  https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js
+// @updateURL    https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.meta.js
 // ==/UserScript==
 
 (function () {
@@ -56,8 +54,8 @@
   const DRA_GUI_RULE_BYE_URL = `${DRA_GUI_RULES_DOC_URL}#dra-gui-rule-bye`;
   const DRA_GUI_RULE_TIE_BREAK_URL = `${DRA_GUI_RULES_DOC_URL}#dra-gui-rule-tie-break`;
   const DRA_GUI_RULE_CHECKLIST_URL = `${DRA_GUI_RULES_DOC_URL}#dra-gui-rule-checklist`;
-  const USERSCRIPT_DOWNLOAD_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.user.js";
-  const USERSCRIPT_UPDATE_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-tournament-assistant.meta.js";
+  const USERSCRIPT_DOWNLOAD_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.user.js";
+  const USERSCRIPT_UPDATE_URL = "https://raw.githubusercontent.com/thomasasen/autodarts_local_tournament/main/dist/autodarts-local-tournament.meta.js";
   const USERSCRIPT_LOADER_URL = "https://github.com/thomasasen/autodarts_local_tournament/raw/refs/heads/main/installer/Autodarts%20Tournament%20Assistant%20Loader.user.js";
   const UPDATE_STATUS_STORAGE_KEY = "ata:update-status:v1";
   const UPDATE_CHECK_TTL_MS = 60 * 60 * 1000;


### PR DESCRIPTION
Jetzt: Dist-first Build mit esbuild, Version aus package.json, installierbares Standard-Artefakt ohne Runtime-Nachladen, Loader bleibt als Legacy-Fallback.